### PR TITLE
dont fail the build if clean fails because of lock

### DIFF
--- a/.shipped/build
+++ b/.shipped/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn clean compile
+mvn clean compile -Dmaven.clean.failOnError=false


### PR DESCRIPTION
Addresses CiscoCloud/shipped#1516 where the /app/targets folder cannot be deleted due to a lock held by another process and this causes the build to fail.
